### PR TITLE
Fix formatting + unstable notes due to ehuss

### DIFF
--- a/grammar/abi.lyg
+++ b/grammar/abi.lyg
@@ -4,29 +4,28 @@ Abi = LITERAL?;
 /*
 // HACK(eddyb) taken from `librustc_target/spec/abi.rs`
 Abi =
-    // Defaults to "C"
-    {} |
-
-    // Platform-specific ABIs
-    "\"cdecl\"" |
-    "\"stdcall\"" |
-    "\"fastcall\"" |
-    "\"vectorcall\"" |
-    "\"thiscall\"" |
-    "\"aapcs\"" |
-    "\"win64\"" |
-    "\"sysv64\"" |
-    "\"ptx-kernel\"" |
-    "\"msp430-interrupt\"" |
-    "\"x86-interrupt\"" |
-    "\"amdgpu-kernel\"" |
-
-    // Cross-platform ABIs
-    "\"Rust\"" |
-    "\"C\"" |
-    "\"system\"" |
-    "\"rust-intrinsic\"" |
-    "\"rust-call\"" |
-    "\"platform-intrinsic\"" |
-    "\"unadjusted\"";
+  // Defaults to "C"
+  | {}
+  // Platform-specific ABIs
+  | "\"cdecl\""
+  | "\"stdcall\""
+  | "\"fastcall\""
+  | "\"vectorcall\""
+  | "\"thiscall\""
+  | "\"aapcs\""
+  | "\"win64\""
+  | "\"sysv64\""
+  | "\"ptx-kernel\""
+  | "\"msp430-interrupt\""
+  | "\"x86-interrupt\""
+  | "\"amdgpu-kernel\""
+  // Cross-platform ABIs
+  | "\"Rust\""
+  | "\"C\""
+  | "\"system\""
+  | "\"rust-intrinsic\""
+  | "\"rust-call\""
+  | "\"platform-intrinsic\""
+  | "\"unadjusted\""
+  ;
 */

--- a/grammar/attr.lyg
+++ b/grammar/attr.lyg
@@ -2,6 +2,7 @@ OuterAttr = "#" attr:Attr;
 InnerAttr = "#" "!" attr:Attr;
 Attr = "[" path:Path input:AttrInput "]";
 AttrInput =
-    {} |
-    "=" TOKEN_TREE |
-    MacroInput;
+  | {}
+  | "=" TOKEN_TREE
+  | MacroInput
+  ;

--- a/grammar/expr.lyg
+++ b/grammar/expr.lyg
@@ -1,123 +1,129 @@
 Expr = attrs:OuterAttr* kind:ExprKind;
 ExprKind =
-    Literal:LITERAL |
-    Paren:{ "(" attrs:InnerAttr* expr:Expr ")" } |
-    Borrow:{ "&" mutable:"mut"? expr:Expr } |
-    Box:{ "box" expr:Expr } |
-    Unary:{ op:UnaryOp expr:Expr } |
-    Try:{ expr:Expr "?" } |
-    Binary:{ left:Expr op:BinaryOp right:Expr } |
-    Assign:{ left:Expr { "=" | op:BinaryAssignOp } right:Expr } |
-    Range:{ start:Expr? ".." end:Expr? } |
-    RangeInclusive:{ start:Expr? "..=" end:Expr } |
-    // unstable(type_ascription):
-    Type:{ expr:Expr ":" ty:Type } |
-    Cast:{ expr:Expr "as" ty:Type } |
-    Field:{ base:Expr "." field:FieldName } |
-    Index:{ base:Expr "[" index:Expr "]" } |
-    Array:{ "[" attrs:InnerAttr* exprs:Expr* % "," ","? "]" } |
-    Repeat:{ "[" attrs:InnerAttr* elem:Expr ";" count:Expr "]" } |
-    Tuple:{ "(" attrs:InnerAttr* exprs:Expr* % "," ","? ")" } |
-    Path:QPath |
-    Call:{ callee:Expr "(" args:Expr* % "," ","? ")" } |
-    MethodCall:{ receiver:Expr "." method:PathSegment "(" args:Expr* % "," ","? ")" } |
-    Struct:{ path:Path "{" attrs:InnerAttr* fields:StructExprFieldsAndBase "}" } |
-    Block:{ { label:Label ":" }? unsafety:"unsafe"? block:Block } |
-    // ustable(async_await):
-    AsyncBlock:{ "async" block:Block } |
-    // unstable(try_block):
-    TryBlock:{ "try" block:Block } |
-    Continue:{ "continue" label:Label? } |
-    Break:{ "break" label:Label? value:Expr? } |
-    Return:{ "return" value:Expr? } |
-    // unstable(generators):
-    Yield:{ "yield" value:Expr? } |
-    If:If |
-    Match:{ "match" expr:Expr "{" attrs:InnerAttr* arms:MatchArm* "}" } |
-    Loop:{ { label:Label ":" }? "loop" body:Block } |
-    While:{ { label:Label ":" }? "while" cond:Cond body:Block } |
-    For:{ { label:Label ":" }? "for" pat:Pat "in" expr:Expr body:Block } |
-    Closure:{
-        // unstable(generators):
-        generator_static:"static"?
-        // unstable(async_await):
-        asyncness:"async"?
-        by_val:"move"?
-        "|" args:ClosureArg* % "," ","? "|" { "->" ret_ty:Type }? body:Expr
-    } |
-    MacroCall:MacroCall;
+  | Literal:LITERAL
+  | Paren:{ "(" attrs:InnerAttr* expr:Expr ")" }
+  | Borrow:{ "&" mutable:"mut"? expr:Expr }
+  | Box:{ "box" expr:Expr }
+  | Unary:{ op:UnaryOp expr:Expr }
+  | Try:{ expr:Expr "?" }
+  | Binary:{ left:Expr op:BinaryOp right:Expr }
+  | Assign:{ left:Expr { "=" | op:BinaryAssignOp } right:Expr }
+  | Range:{ start:Expr? ".." end:Expr? }
+  | RangeInclusive:{ start:Expr? "..=" end:Expr }
+  // unstable(type_ascription):
+  | Type:{ expr:Expr ":" ty:Type }
+  | Cast:{ expr:Expr "as" ty:Type }
+  | Field:{ base:Expr "." field:FieldName }
+  | Index:{ base:Expr "[" index:Expr "]" }
+  | Array:{ "[" attrs:InnerAttr* exprs:Expr* % "," ","? "]" }
+  | Repeat:{ "[" attrs:InnerAttr* elem:Expr ";" count:Expr "]" }
+  | Tuple:{ "(" attrs:InnerAttr* exprs:Expr* % "," ","? ")" }
+  | Path:QPath
+  | Call:{ callee:Expr "(" args:Expr* % "," ","? ")" }
+  | MethodCall:{ receiver:Expr "." method:PathSegment "(" args:Expr* % "," ","? ")" }
+  | Struct:{ path:Path "{" attrs:InnerAttr* fields:StructExprFieldsAndBase "}" }
+  | Block:{ { label:Label ":" }? unsafety:"unsafe"? block:Block }
+  // ustable(async_await):
+  | AsyncBlock:{ "async" block:Block }
+  // unstable(try_block):
+  | TryBlock:{ "try" block:Block }
+  | Continue:{ "continue" label:Label? }
+  | Break:{ "break" label:Label? value:Expr? }
+  | Return:{ "return" value:Expr? }
+  // unstable(generators):
+  | Yield:{ "yield" value:Expr? }
+  | If:If
+  | Match:{ "match" expr:Expr "{" attrs:InnerAttr* arms:MatchArm* "}" }
+  | Loop:{ { label:Label ":" }? "loop" body:Block }
+  | While:{ { label:Label ":" }? "while" cond:Cond body:Block }
+  | For:{ { label:Label ":" }? "for" pat:Pat "in" expr:Expr body:Block }
+  | Closure:{
+      // unstable(generators):
+      generator_static:"static"?
+      // unstable(async_await):
+      asyncness:"async"?
+      by_val:"move"?
+      "|" args:ClosureArg* % "," ","? "|" { "->" ret_ty:Type }? body:Expr
+    }
+  | MacroCall:MacroCall
+  ;
 
 UnaryOp =
-    Not:"!" |
-    Neg:"-" |
-    Deref:"*";
+  | Not:"!"
+  | Neg:"-"
+  | Deref:"*";
 
 BinaryOp =
-    // Arithmetic & bitwise (these also have `BinaryAssignOp` forms)
-    Add:"+" |
-    Sub:"-" |
-    Mul:"*" |
-    Div:"/" |
-    Rem:"%" |
-    BitXor:"^" |
-    BitAnd:"&" |
-    BitOr:"|" |
-    Shl:"<<" |
-    Shr:">>" |
-
-    // Logic (short-circuiting)
-    LogicAnd:"&&" |
-    LogicOr:"||" |
-
-    // Comparisons
-    Eq:"==" |
-    Lt:"<" |
-    Le:"<=" |
-    Ne:"!=" |
-    Gt:">" |
-    Ge:">=";
+  // Arithmetic & bitwise (these also have `BinaryAssignOp` forms)
+  | Add:"+"
+  | Sub:"-"
+  | Mul:"*"
+  | Div:"/"
+  | Rem:"%"
+  | BitXor:"^"
+  | BitAnd:"&"
+  | BitOr:"|"
+  | Shl:"<<"
+  | Shr:">>"
+  // Logic (short-circuiting)
+  | LogicAnd:"&&"
+  | LogicOr:"||"
+  // Comparisons
+  | Eq:"=="
+  | Lt:"<"
+  | Le:"<="
+  | Ne:"!="
+  | Gt:">"
+  | Ge:">="
+  ;
 
 // FIXME(eddyb) figure out how to deduplicate this with `BinaryOp`
 // The problem is something like `BinaryOp "="` allows a space in between,
 // as the last token inside each `BinaryOp` case does not require being
 // joint, but each token before the `=` here does impose that requirement.
 BinaryAssignOp =
-    Add:"+=" |
-    Sub:"-=" |
-    Mul:"*=" |
-    Div:"/=" |
-    Rem:"%=" |
-    BitXor:"^=" |
-    BitAnd:"&=" |
-    BitOr:"|=" |
-    Shl:"<<=" |
-    Shr:">>=";
+  | Add:"+="
+  | Sub:"-="
+  | Mul:"*="
+  | Div:"/="
+  | Rem:"%="
+  | BitXor:"^="
+  | BitAnd:"&="
+  | BitOr:"|="
+  | Shl:"<<="
+  | Shr:">>="
+  ;
 
 FieldName =
-    Ident:IDENT |
-    // FIXME(eddyb) restrict this to only integer literals
-    Numeric:LITERAL;
+  | Ident:IDENT
+  // FIXME(eddyb) restrict this to only integer literals
+  | Numeric:LITERAL
+  ;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
 StructExprFieldsAndBase =
-    Fields:{ fields:StructExprField* % "," ","? } |
-    Base:{ ".." base:Expr } |
-    FieldsAndBase:{ fields:StructExprField+ % "," "," ".." base:Expr };
+  | Fields:{ fields:StructExprField* % "," ","? }
+  | Base:{ ".." base:Expr }
+  | FieldsAndBase:{ fields:StructExprField+ % "," "," ".." base:Expr }
+  ;
 
 StructExprField = attrs:OuterAttr* kind:StructExprFieldKind;
 StructExprFieldKind =
-    Shorthand:IDENT |
-    Explicit:{ field:FieldName ":" expr:Expr };
+  | Shorthand:IDENT
+  | Explicit:{ field:FieldName ":" expr:Expr }
+  ;
 
 Label = LIFETIME;
 
 If = "if" cond:Cond then:Block { "else" else_expr:ElseExpr }?;
 Cond =
-    Bool:Expr |
-    Let:{ "let" pat:Pat "=" expr:Expr };
+  | Bool:Expr
+  | Let:{ "let" pat:Pat "=" expr:Expr }
+  ;
 ElseExpr =
-    Block:Block |
-    If:If;
+  | Block:Block
+  | If:If
+  ;
 
 MatchArm = attrs:OuterAttr* "|"? pats:Pat+ % "|" { "if" guard:Expr }? "=>" body:Expr ","?;
 

--- a/grammar/expr.lyg
+++ b/grammar/expr.lyg
@@ -10,6 +10,7 @@ ExprKind =
     Assign:{ left:Expr { "=" | op:BinaryAssignOp } right:Expr } |
     Range:{ start:Expr? ".." end:Expr? } |
     RangeInclusive:{ start:Expr? "..=" end:Expr } |
+    // unstable(type_ascription):
     Type:{ expr:Expr ":" ty:Type } |
     Cast:{ expr:Expr "as" ty:Type } |
     Field:{ base:Expr "." field:FieldName } |
@@ -22,11 +23,14 @@ ExprKind =
     MethodCall:{ receiver:Expr "." method:PathSegment "(" args:Expr* % "," ","? ")" } |
     Struct:{ path:Path "{" attrs:InnerAttr* fields:StructExprFieldsAndBase "}" } |
     Block:{ { label:Label ":" }? unsafety:"unsafe"? block:Block } |
+    // ustable(async_await):
     AsyncBlock:{ "async" block:Block } |
+    // unstable(try_block):
     TryBlock:{ "try" block:Block } |
     Continue:{ "continue" label:Label? } |
     Break:{ "break" label:Label? value:Expr? } |
     Return:{ "return" value:Expr? } |
+    // unstable(generators):
     Yield:{ "yield" value:Expr? } |
     If:If |
     Match:{ "match" expr:Expr "{" attrs:InnerAttr* arms:MatchArm* "}" } |
@@ -34,7 +38,11 @@ ExprKind =
     While:{ { label:Label ":" }? "while" cond:Cond body:Block } |
     For:{ { label:Label ":" }? "for" pat:Pat "in" expr:Expr body:Block } |
     Closure:{
-        generator_static:"static"? asyncness:"async"? by_val:"move"?
+        // unstable(generators):
+        generator_static:"static"?
+        // unstable(async_await):
+        asyncness:"async"?
+        by_val:"move"?
         "|" args:ClosureArg* % "," ","? "|" { "->" ret_ty:Type }? body:Expr
     } |
     MacroCall:MacroCall;

--- a/grammar/generics.lyg
+++ b/grammar/generics.lyg
@@ -1,36 +1,42 @@
 Generics = "<" params:GenericParam* % "," ","? ">";
 GenericParam = attrs:OuterAttr* kind:GenericParamKind;
 GenericParamKind =
-    Lifetime:{ name:LIFETIME { ":" bounds:LifetimeBound* % "+" "+"? }? } |
-    Type:{ name:IDENT { ":" bounds:TypeBound* % "+" "+"? }? { "=" default:Type }? };
+  | Lifetime:{ name:LIFETIME { ":" bounds:LifetimeBound* % "+" "+"? }? }
+  | Type:{ name:IDENT { ":" bounds:TypeBound* % "+" "+"? }? { "=" default:Type }? }
+  ;
 
 ForAllBinder = "for" generics:Generics;
 
 WhereClause = "where" bounds:WhereBound* % "," ","?;
 WhereBound =
-    Lifetime:{ lt:LIFETIME ":" bounds:LifetimeBound* % "+" "+"? } |
-    Type:{ binder:ForAllBinder? ty:Type ":" bounds:TypeBound* % "+" "+"? } |
-    // unstable:
-    TypeEq:{ binder:ForAllBinder? left:Type { "=" | "==" } right:Type };
+  | Lifetime:{ lt:LIFETIME ":" bounds:LifetimeBound* % "+" "+"? }
+  | Type:{ binder:ForAllBinder? ty:Type ":" bounds:TypeBound* % "+" "+"? }
+  // unstable(#20041):
+  | TypeEq:{ binder:ForAllBinder? left:Type { "=" | "==" } right:Type }
+  ;
 
 LifetimeBound = outlives:LIFETIME;
 TypeBound =
-    Outlives:LIFETIME |
-    Trait:TypeTraitBound |
-    TraitParen:{ "(" bound:TypeTraitBound ")" };
+  | Outlives:LIFETIME
+  | Trait:TypeTraitBound
+  | TraitParen:{ "(" bound:TypeTraitBound ")" }
+  ;
 TypeTraitBound = unbound:"?"? binder:ForAllBinder? path:Path;
 
 GenericArgs =
-    AngleBracket:{ "<" args_and_bindings:AngleBracketGenericArgsAndBindings? ","? ">" } |
-    Paren:{ "(" inputs:Type* % "," ","? ")" { "->" output:Type }? };
+  | AngleBracket:{ "<" args_and_bindings:AngleBracketGenericArgsAndBindings? ","? ">" }
+  | Paren:{ "(" inputs:Type* % "," ","? ")" { "->" output:Type }? }
+  ;
 
 // FIXME(eddyb) find a way to express this `A* B*` pattern better
 AngleBracketGenericArgsAndBindings =
-    Args:GenericArg+ % "," |
-    Bindings:TypeBinding+ % "," |
-    ArgsAndBindings:{ args:GenericArg+ % "," "," bindings:TypeBinding+ % "," };
+  | Args:GenericArg+ % ","
+  | Bindings:TypeBinding+ % ","
+  | ArgsAndBindings:{ args:GenericArg+ % "," "," bindings:TypeBinding+ % "," }
+  ;
 
 GenericArg =
-    Lifetime:LIFETIME |
-    Type:Type;
+  | Lifetime:LIFETIME
+  | Type:Type
+  ;
 TypeBinding = name:IDENT "=" ty:Type;

--- a/grammar/generics.lyg
+++ b/grammar/generics.lyg
@@ -10,6 +10,7 @@ WhereClause = "where" bounds:WhereBound* % "," ","?;
 WhereBound =
     Lifetime:{ lt:LIFETIME ":" bounds:LifetimeBound* % "+" "+"? } |
     Type:{ binder:ForAllBinder? ty:Type ":" bounds:TypeBound* % "+" "+"? } |
+    // unstable:
     TypeEq:{ binder:ForAllBinder? left:Type { "=" | "==" } right:Type };
 
 LifetimeBound = outlives:LIFETIME;

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -2,106 +2,117 @@ ModuleContents = attrs:InnerAttr* items:Item*;
 
 Item = attrs:OuterAttr* vis:Vis? kind:ItemKind;
 ItemKind =
-    Use:{ "use" use_tree:UseTree ";" } |
-    ExternCrate:{ "extern" "crate" name:IDENT { "as" rename:IDENT }? ";" } |
-    Mod:{ "mod" name:IDENT { ";" | "{" contents:ModuleContents "}" } } |
-    ForeignMod:{ "extern" abi:Abi "{" attrs:InnerAttr* items:ForeignItem* "}" } |
-    Static:{ "static" mutable:"mut"? name:IDENT ":" ty:Type "=" value:Expr ";" } |
-    Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" } |
-    Fn:{ header:FnHeader "fn" decl:FnDecl body:Block } |
-    TypeAlias:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" } |
-    // unstable(existential_type):
-    ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" } |
-    Enum:{ "enum" name:IDENT generics:Generics? where_clause:WhereClause? "{" variants:EnumVariant* % "," ","? "}" } |
-    Struct:{ "struct" name:IDENT generics:Generics? body:StructBody } |
-    Union:{ "union" name:IDENT generics:Generics? where_clause:WhereClause? "{" fields:RecordField* % "," ","? "}" } |
-    Trait:{
-        unsafety:"unsafe"?
-        // unstable(optin_builtin_traits):
-        auto:"auto"?
-        "trait" name:IDENT generics:Generics?
-        { ":" superbounds:TypeBound* % "+" "+"? }?
-        where_clause:WhereClause? "{" trait_items:TraitItem* "}"
-    } |
-    // unstable(trait_alias):
-    TraitAlias:{
-        "trait" name:IDENT generics:Generics?
+  | Use:{ "use" use_tree:UseTree ";" }
+  | ExternCrate:{ "extern" "crate" name:IDENT { "as" rename:IDENT }? ";" }
+  | Mod:{ "mod" name:IDENT { ";" | "{" contents:ModuleContents "}" } }
+  | ForeignMod:{ "extern" abi:Abi "{" attrs:InnerAttr* items:ForeignItem* "}" }
+  | Static:{ "static" mutable:"mut"? name:IDENT ":" ty:Type "=" value:Expr ";" }
+  | Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" }
+  | Fn:{ header:FnHeader "fn" decl:FnDecl body:Block }
+  | TypeAlias:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" }
+  // unstable(existential_type):
+  | ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" }
+  | Enum:{ "enum" name:IDENT generics:Generics? where_clause:WhereClause? "{" variants:EnumVariant* % "," ","? "}" }
+  | Struct:{ "struct" name:IDENT generics:Generics? body:StructBody }
+  | Union:{ "union" name:IDENT generics:Generics? where_clause:WhereClause? "{" fields:RecordField* % "," ","? "}" }
+  | Trait:{
+      unsafety:"unsafe"?
+      // unstable(optin_builtin_traits):
+      auto:"auto"?
+      "trait" name:IDENT generics:Generics?
+      { ":" superbounds:TypeBound* % "+" "+"? }?
+      where_clause:WhereClause? "{" trait_items:TraitItem* "}"
+    }
+  // unstable(trait_alias):
+  | TraitAlias:{
+    "trait" name:IDENT generics:Generics?
         { ":" superbounds:TypeBound* % "+" "+"? }?
         where_clause:WhereClause? "=" bounds:TypeBound* % "+" "+"? ";"
-    } |
-    Impl:{
-        // unstable(specialization):
-        defaultness:"default"?
-        unsafety:"unsafe"? "impl" generics:Generics?
-        { negate:"!"? trait_path:Path "for" }? ty:Type
-        where_clause:WhereClause? "{" attrs:InnerAttr* impl_items:ImplItem* "}"
-    } |
-    // unstable(decl_macro):
-    Macro:{ "macro" name:IDENT { "(" TOKEN_TREE* ")" }? "{" TOKEN_TREE* "}" } |
-    MacroCall:ItemMacroCall;
+    }
+  | Impl:{
+      // unstable(specialization):
+      defaultness:"default"?
+      unsafety:"unsafe"? "impl" generics:Generics?
+      { negate:"!"? trait_path:Path "for" }? ty:Type
+      where_clause:WhereClause? "{" attrs:InnerAttr* impl_items:ImplItem* "}"
+    }
+  // unstable(decl_macro):
+  | Macro:{ "macro" name:IDENT { "(" TOKEN_TREE* ")" }? "{" TOKEN_TREE* "}" }
+  | MacroCall:ItemMacroCall
+  ;
 
 UseTree =
-    Glob:{ prefix:UseTreePrefix? "*" } |
-    Nested:{ prefix:UseTreePrefix? "{" children:UseTree* % "," ","? "}" } |
-    Simple:{ path:Path { "as" rename:IDENT }? };
+  | Glob:{ prefix:UseTreePrefix? "*" }
+  | Nested:{ prefix:UseTreePrefix? "{" children:UseTree* % "," ","? "}" }
+  | Simple:{ path:Path { "as" rename:IDENT }? }
+  ;
 UseTreePrefix =
-    Path:{ path:Path "::" } |
-    Global:"::";
+  | Path:{ path:Path "::" }
+  | Global:"::"
+  ;
 
 ForeignItem = attrs:OuterAttr* vis:Vis? kind:ForeignItemKind;
 ForeignItemKind =
-    Static:{ "static" mutable:"mut"? name:IDENT ":" ty:Type ";" } |
-    Fn:{ "fn" decl:FnDecl ";" } |
-    // unstable(extern_types):
-    Type:{ "type" name:IDENT ";" } |
-    // unstable(macros_in_extern):
-    MacroCall:ItemMacroCall;
+  | Static:{ "static" mutable:"mut"? name:IDENT ":" ty:Type ";" }
+  | Fn:{ "fn" decl:FnDecl ";" }
+  // unstable(extern_types):
+  | Type:{ "type" name:IDENT ";" }
+  // unstable(macros_in_extern):
+  | MacroCall:ItemMacroCall
+  ;
 
 TraitItem = attrs:OuterAttr* kind:TraitItemKind;
 TraitItemKind =
-    Const:{ "const" name:IDENT ":" ty:Type { "=" default:Expr }? ";" } |
-    Fn:{ header:FnHeader "fn" decl:FnDecl { default_body:Block | ";" } } |
-    Type:{ "type" name:IDENT generics:Generics? { ":" bounds:TypeBound* % "+" "+"? }? where_clause:WhereClause? { "=" default:Type }? ";" } |
-    MacroCall:ItemMacroCall;
+  | Const:{ "const" name:IDENT ":" ty:Type { "=" default:Expr }? ";" }
+  | Fn:{ header:FnHeader "fn" decl:FnDecl { default_body:Block | ";" } }
+  | Type:{ "type" name:IDENT generics:Generics? { ":" bounds:TypeBound* % "+" "+"? }? where_clause:WhereClause? { "=" default:Type }? ";" }
+  | MacroCall:ItemMacroCall
+  ;
 
 ImplItem =
-    attrs:OuterAttr*
-    // unstable(specialization):
-    defaultness:"default"?
-    vis:Vis? kind:ImplItemKind;
+  attrs:OuterAttr*
+  // unstable(specialization):
+  defaultness:"default"?
+  vis:Vis? kind:ImplItemKind
+  ;
 ImplItemKind =
-    Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" } |
-    Fn:{ header:FnHeader "fn" decl:FnDecl body:Block } |
-    Type:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" } |
-    // unstable(existential_type):
-    ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" } |
-    MacroCall:ItemMacroCall;
+  | Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" }
+  | Fn:{ header:FnHeader "fn" decl:FnDecl body:Block }
+  | Type:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" }
+  // unstable(existential_type):
+  | ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" }
+  | MacroCall:ItemMacroCall
+  ;
 
 FnHeader = constness:"const"? unsafety:"unsafe"? asyncness:"async"? { "extern" abi:Abi }?;
 FnDecl = name:IDENT generics:Generics? "(" args:FnArgs? ","? ")" { "->" ret_ty:Type }? where_clause:WhereClause?;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
 FnArgs =
-    Regular:FnArg+ % "," |
-    Variadic:"..." |
-    RegularAndVariadic:{ args:FnArg+ % "," "," "..." };
+  | Regular:FnArg+ % ","
+  | Variadic:"..."
+  | RegularAndVariadic:{ args:FnArg+ % "," "," "..." }
+  ;
 FnArg =
-    SelfValue:{ mutable:"mut"? "self" } |
-    SelfRef:{ "&" lt:LIFETIME? mutable:"mut"? "self" } |
-    Regular:FnSigInput;
+  | SelfValue:{ mutable:"mut"? "self" }
+  | SelfRef:{ "&" lt:LIFETIME? mutable:"mut"? "self" }
+  | Regular:FnSigInput
+  ;
 
 EnumVariant = attrs:OuterAttr* name:IDENT kind:EnumVariantKind { "=" discr:Expr }?;
 EnumVariantKind =
-    Unit:{} |
-    Tuple:{ "(" fields:TupleField* % "," ","? ")" } |
-    Record:{ "{" fields:RecordField* % "," ","? "}" };
+  | Unit:{}
+  | Tuple:{ "(" fields:TupleField* % "," ","? ")" }
+  | Record:{ "{" fields:RecordField* % "," ","? "}" }
+  ;
 
 // FIXME(eddyb) could maybe be shared more with `EnumVariantKind`?
 // The problem is the semicolons for `Unit` and `Tuple`, and the where clauses.
 StructBody =
-    Unit:{ where_clause:WhereClause? ";" } |
-    Tuple:{ "(" fields:TupleField* % "," ","? ")" where_clause:WhereClause? ";" } |
-    Record:{ where_clause:WhereClause? "{" fields:RecordField* % "," ","? "}" };
+  | Unit:{ where_clause:WhereClause? ";" }
+  | Tuple:{ "(" fields:TupleField* % "," ","? ")" where_clause:WhereClause? ";" }
+  | Record:{ where_clause:WhereClause? "{" fields:RecordField* % "," ","? "}" }
+  ;
 
 TupleField = attrs:OuterAttr* vis:Vis? ty:Type;
 RecordField = attrs:OuterAttr* vis:Vis? name:IDENT ":" ty:Type;

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -10,25 +10,33 @@ ItemKind =
     Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" } |
     Fn:{ header:FnHeader "fn" decl:FnDecl body:Block } |
     TypeAlias:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" } |
+    // unstable(existential_type):
     ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" } |
     Enum:{ "enum" name:IDENT generics:Generics? where_clause:WhereClause? "{" variants:EnumVariant* % "," ","? "}" } |
     Struct:{ "struct" name:IDENT generics:Generics? body:StructBody } |
     Union:{ "union" name:IDENT generics:Generics? where_clause:WhereClause? "{" fields:RecordField* % "," ","? "}" } |
     Trait:{
-        unsafety:"unsafe"? auto:"auto"? "trait" name:IDENT generics:Generics?
+        unsafety:"unsafe"?
+        // unstable(optin_builtin_traits):
+        auto:"auto"?
+        "trait" name:IDENT generics:Generics?
         { ":" superbounds:TypeBound* % "+" "+"? }?
         where_clause:WhereClause? "{" trait_items:TraitItem* "}"
     } |
+    // unstable(trait_alias):
     TraitAlias:{
         "trait" name:IDENT generics:Generics?
         { ":" superbounds:TypeBound* % "+" "+"? }?
         where_clause:WhereClause? "=" bounds:TypeBound* % "+" "+"? ";"
     } |
     Impl:{
-        defaultness:"default"? unsafety:"unsafe"? "impl" generics:Generics?
+        // unstable(specialization):
+        defaultness:"default"?
+        unsafety:"unsafe"? "impl" generics:Generics?
         { negate:"!"? trait_path:Path "for" }? ty:Type
         where_clause:WhereClause? "{" attrs:InnerAttr* impl_items:ImplItem* "}"
     } |
+    // unstable(decl_macro):
     Macro:{ "macro" name:IDENT { "(" TOKEN_TREE* ")" }? "{" TOKEN_TREE* "}" } |
     MacroCall:ItemMacroCall;
 
@@ -44,7 +52,9 @@ ForeignItem = attrs:OuterAttr* vis:Vis? kind:ForeignItemKind;
 ForeignItemKind =
     Static:{ "static" mutable:"mut"? name:IDENT ":" ty:Type ";" } |
     Fn:{ "fn" decl:FnDecl ";" } |
+    // unstable(extern_types):
     Type:{ "type" name:IDENT ";" } |
+    // unstable(macros_in_extern):
     MacroCall:ItemMacroCall;
 
 TraitItem = attrs:OuterAttr* kind:TraitItemKind;
@@ -54,11 +64,16 @@ TraitItemKind =
     Type:{ "type" name:IDENT generics:Generics? { ":" bounds:TypeBound* % "+" "+"? }? where_clause:WhereClause? { "=" default:Type }? ";" } |
     MacroCall:ItemMacroCall;
 
-ImplItem = attrs:OuterAttr* defaultness:"default"? vis:Vis? kind:ImplItemKind;
+ImplItem =
+    attrs:OuterAttr*
+    // unstable(specialization):
+    defaultness:"default"?
+    vis:Vis? kind:ImplItemKind;
 ImplItemKind =
     Const:{ "const" name:IDENT ":" ty:Type "=" value:Expr ";" } |
     Fn:{ header:FnHeader "fn" decl:FnDecl body:Block } |
     Type:{ "type" name:IDENT generics:Generics? where_clause:WhereClause? "=" ty:Type ";" } |
+    // unstable(existential_type):
     ExistentialType:{ "existential" "type" name:IDENT generics:Generics? where_clause:WhereClause? ":" bounds:TypeBound* % "+" "+"? ";" } |
     MacroCall:ItemMacroCall;
 

--- a/grammar/macro.lyg
+++ b/grammar/macro.lyg
@@ -1,13 +1,15 @@
 MacroCall = path:Path "!" ident_input:IDENT? input:MacroInput;
 MacroInput =
-    "(" TOKEN_TREE* ")" |
-    "[" TOKEN_TREE* "]" |
-    "{" TOKEN_TREE* "}";
+  | "(" TOKEN_TREE* ")"
+  | "[" TOKEN_TREE* "]"
+  | "{" TOKEN_TREE* "}"
+  ;
 
 // FIXME(eddyb) could maybe be shared more with `MacroInput`?
 // The problem is the semicolons for the `()` and `[]` cases.
 ItemMacroCall = path:Path "!" ident_input:IDENT? input:ItemMacroInput;
 ItemMacroInput =
-    "(" TOKEN_TREE* ")" ";" |
-    "[" TOKEN_TREE* "]" ";" |
-    "{" TOKEN_TREE* "}";
+  | "(" TOKEN_TREE* ")" ";"
+  | "[" TOKEN_TREE* "]" ";"
+  | "{" TOKEN_TREE* "}"
+  ;

--- a/grammar/pat.lyg
+++ b/grammar/pat.lyg
@@ -1,11 +1,13 @@
 Pat =
     Wild:"_" |
     Literal:{ minus:"-"? lit:LITERAL } |
+    // unstable(exclusive_range_pattern):
     Range:{ start:PatRangeValue ".." end:PatRangeValue } |
     RangeInclusive:{ start:PatRangeValue { "..." | "..=" } end:PatRangeValue } |
     Binding:{ binding:Binding { "@" subpat:Pat }? } |
     Paren:{ "(" pat:Pat ")" } |
     Ref:{ "&" mutable:"mut"? pat:Pat } |
+    // unstable(box_patterns):
     Box:{ "box" pat:Pat } |
     Slice:{ "[" elems:SlicePatElem* % "," ","? "]" } |
     Tuple:{ "(" fields:TuplePatField* % "," ","? ")" } |

--- a/grammar/pat.lyg
+++ b/grammar/pat.lyg
@@ -1,41 +1,47 @@
 Pat =
-    Wild:"_" |
-    Literal:{ minus:"-"? lit:LITERAL } |
-    // unstable(exclusive_range_pattern):
-    Range:{ start:PatRangeValue ".." end:PatRangeValue } |
-    RangeInclusive:{ start:PatRangeValue { "..." | "..=" } end:PatRangeValue } |
-    Binding:{ binding:Binding { "@" subpat:Pat }? } |
-    Paren:{ "(" pat:Pat ")" } |
-    Ref:{ "&" mutable:"mut"? pat:Pat } |
-    // unstable(box_patterns):
-    Box:{ "box" pat:Pat } |
-    Slice:{ "[" elems:SlicePatElem* % "," ","? "]" } |
-    Tuple:{ "(" fields:TuplePatField* % "," ","? ")" } |
-    Path:QPath |
-    TupleStruct:{ path:Path "(" fields:TuplePatField* % "," ","? ")" } |
-    Struct:{ path:Path "{" fields:StructPatFieldsAndEllipsis "}" } |
-    MacroCall:MacroCall;
+  | Wild:"_"
+  | Literal:{ minus:"-"? lit:LITERAL }
+  // unstable(exclusive_range_pattern):
+  | Range:{ start:PatRangeValue ".." end:PatRangeValue }
+  | RangeInclusive:{ start:PatRangeValue { "..." | "..=" } end:PatRangeValue }
+  | Binding:{ binding:Binding { "@" subpat:Pat }? }
+  | Paren:{ "(" pat:Pat ")" }
+  | Ref:{ "&" mutable:"mut"? pat:Pat }
+  // unstable(box_patterns):
+  | Box:{ "box" pat:Pat }
+  | Slice:{ "[" elems:SlicePatElem* % "," ","? "]" }
+  | Tuple:{ "(" fields:TuplePatField* % "," ","? ")" }
+  | Path:QPath
+  | TupleStruct:{ path:Path "(" fields:TuplePatField* % "," ","? ")" }
+  | Struct:{ path:Path "{" fields:StructPatFieldsAndEllipsis "}" }
+  | MacroCall:MacroCall
+  ;
 
 PatRangeValue =
-    Literal:{ minus:"-"? lit:LITERAL } |
-    Path:QPath;
+  | Literal:{ minus:"-"? lit:LITERAL }
+  | Path:QPath
+  ;
 
 Binding = boxed:"box"? reference:"ref"? mutable:"mut"? name:IDENT;
 
 SlicePatElem =
-    Subslice:{ subpat:Pat? ".." } |
-    Pat:Pat;
+  | Subslice:{ subpat:Pat? ".." }
+  | Pat:Pat
+  ;
 
 TuplePatField =
-    Ellipsis:".." |
-    Pat:Pat;
+  | Ellipsis:".."
+  | Pat:Pat
+  ;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
 StructPatFieldsAndEllipsis =
-    Fields:{ fields:StructPatField* % "," ","? } |
-    Ellipsis:{ ".." } |
-    FieldsAndEllipsis:{ fields:StructPatField+ % "," "," ".." };
+  | Fields:{ fields:StructPatField* % "," ","? }
+  | Ellipsis:{ ".." }
+  | FieldsAndEllipsis:{ fields:StructPatField+ % "," "," ".." }
+  ;
 
 StructPatField =
-    Shorthand:Binding |
-    Explicit:{ field:FieldName ":" pat:Pat };
+  | Shorthand:Binding
+  | Explicit:{ field:FieldName ":" pat:Pat }
+  ;

--- a/grammar/path.lyg
+++ b/grammar/path.lyg
@@ -4,5 +4,6 @@ PathSegment = ident:IDENT { "::"? args:GenericArgs }?;
 
 QSelf = "<" ty:Type { "as" trait_path:Path }? ">";
 QPath =
-    Unqualified:Path |
-    Qualified:{ qself:QSelf "::" path:RelativePath };
+  | Unqualified:Path
+  | Qualified:{ qself:QSelf "::" path:RelativePath }
+  ;

--- a/grammar/stmt.lyg
+++ b/grammar/stmt.lyg
@@ -1,7 +1,8 @@
 Stmt =
-    Item:Item |
-    Local:{ attrs:OuterAttr* "let" pat:Pat { ":" ty:Type }? { "=" init:Expr }? ";" } |
-    Expr:Expr |
-    Semi:";";
+  | Item:Item
+  | Local:{ attrs:OuterAttr* "let" pat:Pat { ":" ty:Type }? { "=" init:Expr }? ";" }
+  | Expr:Expr
+  | Semi:";"
+  ;
 
 Block = "{" attrs:InnerAttr* Stmt* "}";

--- a/grammar/type.lyg
+++ b/grammar/type.lyg
@@ -1,25 +1,27 @@
 Type =
-    Infer:"_" |
-    Never:"!" |
-    Paren:{ "(" ty:Type ")" } |
-    RawPtr:{ "*" { "const" | mutable:"mut" } pointee:Type } |
-    Ref:{ "&" lt:LIFETIME? mutable:"mut"? pointee:Type } |
-    Slice:{ "[" elem:Type "]" } |
-    Array:{ "[" elem:Type ";" len:Expr "]" } |
-    Tuple:{ "(" tys:Type* % "," ","? ")" } |
-    Path:QPath |
-    FnPtr:{
-        binder:ForAllBinder? unsafety:"unsafe"? { "extern" abi:Abi }?
-        "fn" "(" inputs:FnSigInputs? ","? ")" { "->" ret_ty:Type }?
-    } |
-    ImplTrait:{ "impl" bounds:TypeBound+ % "+" "+"? } |
-    DynTrait:{ "dyn"? bounds:TypeBound+ % "+" "+"? } |
+  | Infer:"_"
+  | Never:"!"
+  | Paren:{ "(" ty:Type ")" }
+  | RawPtr:{ "*" { "const" | mutable:"mut" } pointee:Type }
+  | Ref:{ "&" lt:LIFETIME? mutable:"mut"? pointee:Type }
+  | Slice:{ "[" elem:Type "]" }
+  | Array:{ "[" elem:Type ";" len:Expr "]" }
+  | Tuple:{ "(" tys:Type* % "," ","? ")" }
+  | Path:QPath
+  | FnPtr:{
+      binder:ForAllBinder? unsafety:"unsafe"? { "extern" abi:Abi }?
+      "fn" "(" inputs:FnSigInputs? ","? ")" { "->" ret_ty:Type }?
+    }
+  | ImplTrait:{ "impl" bounds:TypeBound+ % "+" "+"? }
+  | DynTrait:{ "dyn"? bounds:TypeBound+ % "+" "+"? }
     // unstable(not exposed to users):
-    TypeOf:{ "typeof" "(" expr:Expr ")" } |
-    MacroCall:MacroCall;
+  | TypeOf:{ "typeof" "(" expr:Expr ")" }
+  | MacroCall:MacroCall
+  ;
 
 FnSigInputs =
-    Regular:FnSigInput+ % "," |
-    Variadic:"..." |
-    RegularAndVariadic:{ inputs:FnSigInput+ % "," "," "..." };
+  | Regular:FnSigInput+ % ","
+  | Variadic:"..."
+  | RegularAndVariadic:{ inputs:FnSigInput+ % "," "," "..." }
+  ;
 FnSigInput = { pat:Pat ":" }? ty:Type;

--- a/grammar/type.lyg
+++ b/grammar/type.lyg
@@ -14,6 +14,7 @@ Type =
     } |
     ImplTrait:{ "impl" bounds:TypeBound+ % "+" "+"? } |
     DynTrait:{ "dyn"? bounds:TypeBound+ % "+" "+"? } |
+    // unstable(not exposed to users):
     TypeOf:{ "typeof" "(" expr:Expr ")" } |
     MacroCall:MacroCall;
 

--- a/grammar/vis.lyg
+++ b/grammar/vis.lyg
@@ -1,4 +1,5 @@
 Vis =
+    // unstable(crate_visibility_modifier):
     Crate:"crate" |
     Pub:"pub" |
     Restricted:{ "pub" "(" restriction:VisRestriction ")" };

--- a/grammar/vis.lyg
+++ b/grammar/vis.lyg
@@ -1,10 +1,12 @@
 Vis =
-    // unstable(crate_visibility_modifier):
-    Crate:"crate" |
-    Pub:"pub" |
-    Restricted:{ "pub" "(" restriction:VisRestriction ")" };
+  // unstable(crate_visibility_modifier):
+  | Crate:"crate"
+  | Pub:"pub"
+  | Restricted:{ "pub" "(" restriction:VisRestriction ")" }
+  ;
 VisRestriction =
-    Crate:"crate" |
-    Self_:"self" |
-    Super:"super" |
-    Path:{ "in" path:Path };
+  | Crate:"crate"
+  | Self_:"self"
+  | Super:"super"
+  | Path:{ "in" path:Path }
+  ;


### PR DESCRIPTION
As per discussion in https://github.com/rust-lang-nursery/wg-grammar/issues/15.
This also includes `unstable(gate)` comments as per @ehuss's notes.